### PR TITLE
Make integration SDK a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/jupiter-integration-veracode",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A JupiterOne managed integration for https://www.veracode.com",
   "main": "index.js",
   "repository": "https://github.com/jupiterone-io/managed-integration-veracode",

--- a/package.json
+++ b/package.json
@@ -19,15 +19,18 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jupiterone/jupiter-managed-integration-sdk": "^19.0.4",
     "@lifeomic/veracode-client-js": "^0.1.1",
     "bunyan": "^1.8.12"
+  },
+  "peerDependencies": {
+    "@jupiterone/jupiter-managed-integration-sdk": "^19.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.2.2",
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-typescript": "^7.1.0",
+    "@jupiterone/jupiter-managed-integration-sdk": "^19.0.6",
     "@types/bunyan": "^1.8.5",
     "@types/jest": "^22.2.3",
     "@types/node": "^10.12.20",

--- a/yarn.lock
+++ b/yarn.lock
@@ -653,10 +653,10 @@
     log-update "^2.3.0"
     strip-ansi "^3.0.1"
 
-"@jupiterone/jupiter-managed-integration-sdk@^19.0.4":
-  version "19.0.4"
-  resolved "https://registry.npmjs.org/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-19.0.4.tgz#d7d67cf48f993630c60eb1e3f08d0fd8748c957d"
-  integrity sha512-XganV2PBI2tC9RdS1aLETK0RQXbi79Ym7RmTL20JSF88jeyn67wYebohsmKjN82YlO6tUlgQ99tq6z2dq2QRIA==
+"@jupiterone/jupiter-managed-integration-sdk@^19.0.6":
+  version "19.0.6"
+  resolved "https://registry.npmjs.org/@jupiterone/jupiter-managed-integration-sdk/-/jupiter-managed-integration-sdk-19.0.6.tgz#c2d44ff3e79163508c26b19d0b3d9268945ce5e8"
+  integrity sha512-sqjAlhZZKQKnRJpruv8aM+FXuAjC/DTmQoRP5maVqFDs11y8bJBuTmHHpJeIoDr8IXgA2iW7gBwToHXYk9dXEA==
 
 "@lifeomic/veracode-client-js@^0.1.1":
   version "0.1.1"


### PR DESCRIPTION
This is so we can upgrade the SDK in the deployment projects without having to push a dumb version PR to every open source project as well.