### PR TITLE
Fix CWE mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/jupiter-integration-veracode",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A JupiterOne managed integration for https://www.veracode.com",
   "main": "index.js",
   "repository": "https://github.com/jupiterone-io/managed-integration-veracode",

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -144,7 +144,7 @@ function toServiceEntity(finding: FindingData): ServiceEntity {
 function toCWEEntity(finding: FindingData): CWEEntity {
   return {
     _class: "Weakness",
-    _key: finding.cwe.id.toString(),
+    _key: finding.cwe.id,
     _type: "cwe",
     description: finding.cwe.description,
     displayName: finding.cwe.name,
@@ -250,7 +250,7 @@ export function toVulnerabilityCWERelationship(
       relationshipDirection: RelationshipDirection.FORWARD,
       sourceEntityKey: vulnerabilityEntity._key,
       targetEntity: cweEntity,
-      targetFilterKeys: ["id", "_type"],
+      targetFilterKeys: [["id", "_type"]],
     },
 
     displayName: "EXPLOITS",


### PR DESCRIPTION
If you use `["id", "_type"]`, the mapper searches for anything that matches on "id" *or* "_type". If you want your target to match both, you have to use `[["id", "_type"]]`. I have the big retarded. 😭 