### PR TITLE
Add createdOn to findings & vulnerabilities

### DIFF
--- a/src/converters.test.ts
+++ b/src/converters.test.ts
@@ -74,6 +74,7 @@ describe("findings", () => {
       _key: "veracode-finding-guid",
       _type: "veracode_finding",
       displayName: "name",
+      createdOn: 1555969433000,
       foundDate: 1555969433000,
       modifiedDate: 1555969433000,
       name: "name",
@@ -105,6 +106,7 @@ describe("findings", () => {
       _key: "veracode-finding-guid",
       _type: "veracode_finding",
       displayName: "name",
+      createdOn: 1555969433000,
       foundDate: 1555969433000,
       modifiedDate: 1555969433000,
       name: "name",
@@ -128,22 +130,27 @@ describe("findings", () => {
 });
 
 test("vulnerabilities", () => {
-  expect(toVulnerabilityEntity(findingData)).toEqual({
+  expect(toVulnerabilityEntity(findingData, application)).toEqual({
     _class: "Vulnerability",
     _key: "veracode-vulnerability-id",
     _type: "veracode_vulnerability",
-    category: "application",
-    cvss: 1,
-    cwe: "id",
-    description: "description",
-    displayName: "name",
-    exploitability: "Unlikely",
     id: "id",
+    cwe: "id",
+
+    createdOn: 1555969433000,
+
+    displayName: "name",
     name: "name",
-    numericExploitability: -1,
-    numericSeverity: 1,
-    public: false,
+    description: "description",
+    category: "application",
     scanType: "scan_type",
+
+    cvss: 1,
+    numericExploitability: -1,
+    exploitability: "Unlikely",
+    numericSeverity: 1,
     severity: "Low",
+
+    public: false,
   });
 });

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -159,24 +159,33 @@ const exploitabilityMap: { [numericExploitability: number]: string } = {
 
 export function toVulnerabilityEntity(
   finding: FindingData,
+  application: ApplicationData,
 ): VulnerabilityEntity {
+  const findingStatus = finding.finding_status[application.guid];
+
   return {
     _class: "Vulnerability",
     _key: `veracode-vulnerability-${finding.finding_category.id}`,
     _type: VERACODE_VULNERABILITY_ENTITY_TYPE,
-    category: "application",
-    cvss: finding.cvss,
+
+    id: finding.finding_category.id,
     cwe: finding.cwe.id,
-    description: finding.description,
+
+    createdOn: getTime(findingStatus.found_date)!,
+
     displayName: finding.finding_category.name,
+    name: finding.finding_category.name,
+    description: finding.description,
+    category: "application",
+    scanType: finding.scan_type,
+
+    cvss: finding.cvss,
     numericExploitability: finding.exploitability,
     exploitability: exploitabilityMap[finding.exploitability],
-    id: finding.finding_category.id,
-    name: finding.finding_category.name,
-    public: false,
-    scanType: finding.scan_type,
     numericSeverity: finding.severity,
     severity: severityMap[finding.severity],
+
+    public: false,
   };
 }
 
@@ -206,6 +215,7 @@ export function toFindingEntity(
     exploitability: exploitabilityMap[finding.exploitability],
     scanType: finding.scan_type,
 
+    createdOn: getTime(findingStatus.found_date)!,
     foundDate: getTime(findingStatus.found_date)!,
     modifiedDate: getTime(findingStatus.modified_date)!,
     reopenedDate: getTime(findingStatus.reopened_date),

--- a/src/synchronize.test.ts
+++ b/src/synchronize.test.ts
@@ -1,10 +1,30 @@
-import { createTestIntegrationExecutionContext } from "@jupiterone/jupiter-managed-integration-sdk";
-import mockVeracodeClient from "../test/helpers/mockVeracodeClient";
-import synchronize from "./synchronize";
+const getApplicationsMock = jest.fn();
+const getFindingsMock = jest.fn();
 
-jest.mock("@jupiterone/veracode-client", () => {
-  return jest.fn().mockImplementation(() => mockVeracodeClient);
+jest.doMock("@jupiterone/veracode-client", () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      getApplications: getApplicationsMock,
+      getFindings: getFindingsMock,
+    };
+  });
 });
+
+import {
+  createTestIntegrationExecutionContext,
+  EntityOperation,
+  EntityOperationType,
+  RelationshipOperation,
+} from "@jupiterone/jupiter-managed-integration-sdk";
+import {
+  CreateEntityOperation,
+  UpdateEntityOperation,
+} from "@jupiterone/jupiter-managed-integration-sdk/jupiter-types";
+
+import { mockApplication, mockFinding } from "../test/helpers/mockData";
+import { VERACODE_VULNERABILITY_ENTITY_TYPE } from "./constants";
+import { toVulnerabilityEntity } from "./converters";
+import synchronize from "./synchronize";
 
 const persisterOperations = {
   created: 1,
@@ -12,14 +32,17 @@ const persisterOperations = {
   updated: 0,
 };
 
-test("compiles and runs", async () => {
-  const executionContext = createTestIntegrationExecutionContext();
+const testContext = {
+  instance: {
+    config: {
+      veracodeApiId: "some-id",
+      veracodeApiSecret: "some-secret",
+    },
+  },
+};
+const executionContext = createTestIntegrationExecutionContext(testContext);
 
-  executionContext.instance.config = {
-    veracodeApiId: "some-id",
-    veracodeApiSecret: "some-secret",
-  };
-
+beforeAll(() => {
   jest
     .spyOn(executionContext.clients.getClients().graph, "findEntities")
     .mockResolvedValue([]);
@@ -34,7 +57,96 @@ test("compiles and runs", async () => {
       "publishPersisterOperations",
     )
     .mockResolvedValue(persisterOperations);
+});
 
+beforeEach(() => {
+  getApplicationsMock.mockReset();
+  getFindingsMock.mockReset();
+  getApplicationsMock.mockResolvedValue([mockApplication]);
+  getFindingsMock.mockResolvedValue([mockFinding]);
+});
+
+test("compiles and runs", async () => {
   const result = await synchronize(executionContext);
   expect(result).toEqual(persisterOperations);
+});
+
+test("vulnerability should take oldest finding date", async () => {
+  const olderCreatedOn = new Date("2001-09-11T08:56:00.000Z");
+  const olderFinding = { ...mockFinding };
+  olderFinding.finding_status = {
+    [mockApplication.guid]: {
+      ...olderFinding.finding_status[mockApplication.guid],
+      found_date: olderCreatedOn.toISOString(),
+    },
+  };
+
+  getFindingsMock.mockResolvedValue([olderFinding, mockFinding]);
+
+  await synchronize(executionContext);
+
+  expect(executionContext.clients.getClients().persister
+    .publishPersisterOperations as jest.Mock).toBeCalledTimes(1);
+
+  const call = (executionContext.clients.getClients().persister
+    .publishPersisterOperations as jest.Mock).mock.calls[0];
+  const operationsFromFindings: [EntityOperation[], RelationshipOperation[]] =
+    call[1];
+  const entityOperationsFromFindings = operationsFromFindings[0];
+  const nonCreateOperations = entityOperationsFromFindings.filter(
+    operation => operation.type !== EntityOperationType.CREATE_ENTITY,
+  );
+
+  expect(nonCreateOperations.length).toBe(0);
+
+  const createVulnerabilityOperations = (entityOperationsFromFindings as CreateEntityOperation[]).filter(
+    operation => operation.entityType === VERACODE_VULNERABILITY_ENTITY_TYPE,
+  );
+
+  expect(createVulnerabilityOperations.length).toBe(1);
+  // Should only update displayName, since the vertex in the graph has the older
+  // createdOn date.
+  expect(createVulnerabilityOperations[0].properties!.createdOn).toEqual(
+    olderCreatedOn.getTime(),
+  );
+});
+
+test("vulnerability should keep older dates from graph", async () => {
+  jest
+    .spyOn(executionContext.clients.getClients().graph, "findAllEntitiesByType")
+    .mockImplementation(async type => {
+      if (type === VERACODE_VULNERABILITY_ENTITY_TYPE) {
+        const existingVulnerability = toVulnerabilityEntity(
+          mockFinding,
+          mockApplication,
+        );
+        const olderDate = new Date("2001-09-11T08:56:00.000Z").getTime();
+        existingVulnerability.createdOn = olderDate;
+        // Something other than the dates needs to be different. Otherwise, the
+        // operation is not sent because processEntities detects that there are
+        // no changes.
+        existingVulnerability.displayName = "Kill Bill 3";
+        return [existingVulnerability];
+      }
+
+      return [];
+    });
+
+  await synchronize(executionContext);
+
+  const call = (executionContext.clients.getClients().persister
+    .publishPersisterOperations as jest.Mock).mock.calls[0];
+  const operationsFromFindings: [EntityOperation[], RelationshipOperation[]] =
+    call[1];
+  const entityOperationsFromFindings = operationsFromFindings[0];
+  const updateEntityOperations = entityOperationsFromFindings.filter(
+    operation => operation.type === EntityOperationType.UPDATE_ENTITY,
+  ) as UpdateEntityOperation[];
+
+  expect(updateEntityOperations.length).toBe(1);
+  // Should only update displayName, since the vertex in the graph has the older
+  // createdOn date.
+  expect(updateEntityOperations[0].properties).toEqual({
+    displayName: "A Nice Category",
+  });
 });

--- a/src/synchronize.ts
+++ b/src/synchronize.ts
@@ -46,9 +46,20 @@ function processFindings(
   const findingMap: FindingEntityMap = {};
 
   for (const finding of findings) {
-    vulnerabilityMap[finding.finding_category.id] = toVulnerabilityEntity(
-      finding,
-    );
+    const vulnerability = toVulnerabilityEntity(finding, application);
+    const existingVulnerability = vulnerabilityMap[finding.finding_category.id];
+
+    // For a given finding category, the only differentiator between resulting
+    // vulnerabilities should be createdOn. We want to keep the older createdOn
+    // because a vulnerability's createdOn should be the date of the earliest
+    // finding of the vulnerability.
+    if (
+      !existingVulnerability ||
+      (existingVulnerability &&
+        existingVulnerability.createdOn > vulnerability.createdOn)
+    ) {
+      vulnerabilityMap[finding.finding_category.id] = vulnerability;
+    }
 
     cweMap[finding.cwe.id] = toCWEEntity(finding);
     serviceMap[finding.scan_type] = toServiceEntity(finding);

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,17 +29,22 @@ export interface VulnerabilityEntityMap {
 
 export interface VulnerabilityEntity extends EntityFromIntegration {
   id: string;
-  category: string;
-  cvss?: number;
   cwe: string;
+
+  createdOn: number;
+
+  name: string;
   description?: string;
+  category: string;
+  scanType: string;
+
+  cvss?: number;
   numericExploitability: number;
   exploitability: string;
-  name: string;
-  public: boolean;
   numericSeverity: number;
   severity: string;
-  scanType: string;
+
+  public: boolean;
 }
 
 export interface FindingEntityMap {
@@ -61,6 +66,7 @@ export interface FindingEntity extends EntityFromIntegration {
   exploitability: string;
   scanType: string;
 
+  createdOn: number;
   foundDate: number;
   modifiedDate: number;
   reopenedDate?: number;

--- a/test/helpers/mockData.ts
+++ b/test/helpers/mockData.ts
@@ -1,13 +1,13 @@
 import { ApplicationData, FindingData } from "../../src/converters";
 
-const mockApplication: ApplicationData = {
+export const mockApplication: ApplicationData = {
   guid: "some-guid",
   profile: {
     name: "my-app",
   },
 };
 
-const mockFinding: FindingData = {
+export const mockFinding: FindingData = {
   cvss: 50,
   cwe: {
     description: "This vulnerability is very bad.",
@@ -46,8 +46,8 @@ const mockFinding: FindingData = {
       resolution_status: "NONE",
       status: "OPEN",
 
-      found_date: Date.now().toString(),
-      modified_date: Date.now().toString(),
+      found_date: new Date().toISOString(),
+      modified_date: new Date().toISOString(),
 
       finding_source: {
         file_line_number: "420",
@@ -60,14 +60,4 @@ const mockFinding: FindingData = {
   guid: "another-guid",
   scan_type: "STATIC",
   severity: 3,
-};
-
-export default {
-  getApplications() {
-    return [mockApplication];
-  },
-
-  getFindings() {
-    return [mockFinding];
-  },
 };


### PR DESCRIPTION
This turned out to be a little more complicated that I was expecting, partially due to testing and being forced to retain coverage.

The way `createdOn` works for vulnerabilities is a little different from findings. Basically, it's the found date of the first finding of the vulnerability. When we create a vulnerability, we use the oldest finding's found date. When we update, we use the `createdOn` value that's in the graph (unless the new value is older somehow).